### PR TITLE
Support patch command from subdirectories

### DIFF
--- a/src/Composer/PatchAddCommand.php
+++ b/src/Composer/PatchAddCommand.php
@@ -5,11 +5,10 @@ namespace szeidler\ComposerPatchesCLI\Composer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
-use Composer\Command\BaseCommand;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
 
-class PatchAddCommand extends BaseCommand {
+class PatchAddCommand extends PatchBaseCommand {
 
   protected function configure() {
     $this->setName('patch-add')
@@ -19,6 +18,8 @@ class PatchAddCommand extends BaseCommand {
         new InputArgument('description', InputArgument::REQUIRED),
         new InputArgument('url', InputArgument::REQUIRED),
       ]);
+
+    parent::configure();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Composer/PatchBaseCommand.php
+++ b/src/Composer/PatchBaseCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace szeidler\ComposerPatchesCLI\Composer;
+
+use Composer\Factory;
+use Composer\Command\BaseCommand;
+
+class PatchBaseCommand extends BaseCommand {
+
+  protected function configure() {
+    $this->changeWorkingDirToComposerRoot();
+  }
+
+  protected function changeWorkingDirToComposerRoot() {
+    $io = $this->getIO();
+    $dir = dirname(getcwd());
+    $home = realpath(getenv('HOME') ?: getenv('USERPROFILE') ?: '/');
+    // abort when we reach the home dir or top of the filesystem
+    while (dirname($dir) !== $dir && $dir !== $home) {
+      if (file_exists($dir . '/' . Factory::getComposerFile())) {
+        if ($io->askConfirmation('<info>No composer.json in current directory, do you want to use the one at ' . $dir . '?</info> [<comment>Y,n</comment>]? ', TRUE)) {
+          $oldWorkingDir = getcwd();
+          chdir($dir);
+        }
+        break;
+      }
+      $dir = dirname($dir);
+    }
+  }
+
+}

--- a/src/Composer/PatchEnableCommand.php
+++ b/src/Composer/PatchEnableCommand.php
@@ -5,11 +5,10 @@ namespace szeidler\ComposerPatchesCLI\Composer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Composer\Command\BaseCommand;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;
 
-class PatchEnableCommand extends BaseCommand {
+class PatchEnableCommand extends PatchBaseCommand {
 
   protected function configure() {
     $default_file_name = 'composer.patches.json';
@@ -22,6 +21,8 @@ class PatchEnableCommand extends BaseCommand {
         'Which file name should your patch file use.',
         $default_file_name
       );
+
+    parent::configure();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {


### PR DESCRIPTION
Add a PatchBaseCommand, that automatically changes the working directory to the root composer.json

Mimics the support for calling Composer from subdirectories.

It's intended to resolve #1 