### PR TITLE
Suggest global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Composer Patches CLI provides a simple CLI for [cweagans/composer-patches](h
 
 Add Composer Patches CLI as a composer dependency.
 
-`composer require szeidler/composer-patches-cli:dev-master`
+`composer global require szeidler/composer-patches-cli:dev-master`
 
 ## Usage
 


### PR DESCRIPTION
I could be wrong, but I'm guessing most people who'd want to use this package would want to install it globally, rather than installing it on every single individual project, since it provides a universal CLI for installing patches. The only reason I could see to install it as a project dependency would be if you were using it as part of a CI process or something.