### PR TITLE
Allow PHP 8 use in composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "require": {
     "composer-plugin-api": "^1.0 || ^2.0",
     "cweagans/composer-patches": "^1.7",
-    "php": "^7.0"
+    "php": "^7.0||^8.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
See https://github.com/szeidler/composer-patches-cli/issues/27