### PR TITLE
Add license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "szeidler/composer-patches-cli",
   "type": "composer-plugin",
+  "license": "MIT",
   "require": {
     "composer-plugin-api": "^1.0 || ^2.0",
     "cweagans/composer-patches": "^1.7",


### PR DESCRIPTION
To avoid this warning on https://packagist.org/packages/szeidler/composer-patches-cli:
> There is no license information available for the latest version (1.0.5) of this package.