### PR TITLE
Don't update dependencies when adding a patch to a package

### DIFF
--- a/src/Composer/PatchAddCommand.php
+++ b/src/Composer/PatchAddCommand.php
@@ -165,7 +165,7 @@ class PatchAddCommand extends PatchBaseCommand {
             // Only update the current package
             ->setUpdateAllowList([$package])
             // Don't update the dependencies of the patched package.
-            ->setUpdateAllowTransitiveDependencies(Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS_NO_ROOT_REQUIRE)
+            ->setUpdateAllowTransitiveDependencies(Request::UPDATE_ONLY_LISTED)
             // Patches are always considered to be applied in "dev mode".
             // This is also required to prevent composer from removing all installed
             // dev dependencies.


### PR DESCRIPTION
First attempt at solving #30 , though it would still allow unintentionally updating the package being patched too, so still isn't a full solution.

I also realise this doesn't change anything under Composer v1.