### PR TITLE
Provide command to transform all defined remote patches to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ Package: drupal/core
 +-----------------------------------------+-------------------------------------------------------------------------------------------------+
 ```
 
+### Move remote patches to local files.
+
+```sh
+composer patch-move-to-local <directory>
+```
+
+Using remote patches has security implications. Therefore it is wise to store them locally. This command will
+download all remote patches and store them in the given directory. The command will also update your composer.json or
+composer.patches.json.
+
+The move remote patches to local files command accepts the following arguments.
+
+1. `<directory>` The name of the directory the files should be placed in.
+
+Example:
+
+```sh
+composer patch-move-to-local patches
+```
+
 ## Credits
 
 Stephan Zeidler for [Ramsalt Lab AS](https://ramsalt.com)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Package: drupal/core
 ### Move remote patches to local files.
 
 ```sh
-composer patch-move-to-local <directory>
+composer patch-remote-to-local <directory>
 ```
 
 Using remote patches has security implications. Therefore it is wise to store them locally. This command will
@@ -120,7 +120,7 @@ The move remote patches to local files command accepts the following arguments.
 Example:
 
 ```sh
-composer patch-move-to-local patches
+composer patch-remote-to-local patches
 ```
 
 ## Credits

--- a/src/Composer/CommandProvider.php
+++ b/src/Composer/CommandProvider.php
@@ -15,6 +15,7 @@ class CommandProvider implements CommandProviderCapability {
       new PatchAddCommand(),
       new PatchRemoveCommand(),
       new PatchListCommand(),
+      new PatchMoveToLocalCommand(),
     ];
   }
 }

--- a/src/Composer/PatchMoveToLocalCommand.php
+++ b/src/Composer/PatchMoveToLocalCommand.php
@@ -12,8 +12,8 @@ use Composer\Util\HttpDownloader;
 class PatchMoveToLocalCommand extends PatchBaseCommand {
 
   protected function configure() {
-    $this->setName('patch-move-to-local')
-      ->setDescription('Moves all remote patches to local.')
+    $this->setName('patch-remote-to-local')
+      ->setDescription('Convert all remote patches to local stored ones.')
       ->setDefinition([
         new InputArgument('directory', InputArgument::REQUIRED, 'The directory where the patches should be moved to.')
       ]);

--- a/src/Composer/PatchMoveToLocalCommand.php
+++ b/src/Composer/PatchMoveToLocalCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace szeidler\ComposerPatchesCLI\Composer;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Composer\Json\JsonFile;
+use Composer\Json\JsonManipulator;
+use Composer\Util\HttpDownloader;
+
+class PatchMoveToLocalCommand extends PatchBaseCommand {
+
+  protected function configure() {
+    $this->setName('patch-move-to-local')
+      ->setDescription('Moves all remote patches to local.')
+      ->setDefinition([
+        new InputArgument('directory', InputArgument::REQUIRED, 'The directory where the patches should be moved to.')
+      ]);
+
+    parent::configure();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $extra = $this->getComposer()->getPackage()->getExtra();
+
+    if ($this->getPatchType() === self::PATCHTYPE_ROOT) {
+      $manipulator_filename = 'composer.json';
+      $json_node = 'extra';
+      $json_name = 'patches';
+    }
+    elseif ($this->getPatchType() === self::PATCHTYPE_FILE) {
+      $manipulator_filename = $extra['patches-file'];
+      $json_node = null;
+      $json_name = 'patches';
+    }
+    else {
+      throw new \Exception('Composer patches seems to be not enabled. Please enable composer patches first.');
+    }
+
+    $downloader = new HttpDownloader($this->getIO(), $this->getComposer()->getConfig());
+
+    // Grab the defined patches.
+    $patches = $this->grabPatches();
+
+    $file = new JsonFile($manipulator_filename);
+    $manipulator = new JsonManipulator(file_get_contents($file->getPath()));
+    $modified = FALSE;
+
+    foreach ($patches as $package => $packagePatches) {
+      foreach ($packagePatches as $description => $url) {
+        // Only move remote patches.
+        if (filter_var($url, FILTER_VALIDATE_URL)) {
+          // Create the patch directory if not existing.
+          $directory = $input->getArgument('directory');
+          if (!is_dir($directory)) {
+            mkdir($directory);
+          }
+
+          // Move the patch file.
+          $filename = basename($url);
+
+          // A Gitlab merge request file name 1.diff is meaning less.
+          // Therefore, prefix it with the description.
+          if (str_contains($url, '/-/merge_requests/')) {
+            $clean_description = str_replace(' ', '-', $description);
+            $clean_description = strtolower($clean_description);
+            $clean_description = preg_replace('/[^A-Za-z0-9\-]/', '', $clean_description);
+            $filename = $clean_description . '-' . $filename;
+          }
+
+          // Download the remote patch and place it to the destination folder.
+          $source = $url;
+          $destination = $directory . '/' . $filename;
+          if ($downloader->copy($source, $destination)) {
+            $modified = TRUE;
+            $patches[$package][$description] = $destination;
+            if ($this->getIO()->isVerbose()) {
+              $output->writeln('Moved patch: ' . $description . ' | ' . $url . ' to ' . $destination);
+            }
+          }
+          else {
+            throw new \Exception('Patch file could not be moved.');
+          }
+        }
+      }
+    }
+
+    if (!$modified) {
+      $this->getIO()->write('<info>No patches modified.</info>');
+      return 0;
+    }
+
+    // Replace the remote URL with the local path.
+    // Merge in the updated packages into the JSON.
+    if (is_null($json_node)) {
+      $manipulator->removeMainKey('patches');
+      $manipulator->addMainKey('patches', $patches);
+    }
+    else {
+      $manipulator->addSubNode($json_node, $json_name, $patches);
+    }
+
+    if (file_put_contents($manipulator_filename, $manipulator->getContents())) {
+      $this->getIO()->write('<info>Remote Composer patches got successfully moved to local files and got updated in the composer.json or composer.patches.json.</info>');
+    }
+    else {
+      throw new \Exception('Composer patches file could not be saved. Please check the permissions.');
+    }
+
+    return 0;
+  }
+}


### PR DESCRIPTION
Run with `composer patch-move-to-local <yourdirectory>`

Fixes #33