### PR TITLE
Compatibility with Symfony 7

### DIFF
--- a/src/Composer/PatchAddCommand.php
+++ b/src/Composer/PatchAddCommand.php
@@ -63,7 +63,7 @@ class PatchAddCommand extends PatchBaseCommand {
     }
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $extra = $extra = $this->getComposer()->getPackage()->getExtra();
     $package = $input->getArgument('package');
     $description = $input->getArgument('description');

--- a/src/Composer/PatchEnableCommand.php
+++ b/src/Composer/PatchEnableCommand.php
@@ -23,7 +23,7 @@ class PatchEnableCommand extends PatchBaseCommand {
     parent::configure();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $extra = $this->getComposer()->getPackage()->getExtra();
 
     // Check, if patch file is already defined.

--- a/src/Composer/PatchListCommand.php
+++ b/src/Composer/PatchListCommand.php
@@ -23,7 +23,7 @@ class PatchListCommand extends PatchBaseCommand {
     parent::configure();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $formatter = $this->getHelper('formatter');
     $package = $input->getArgument('package');
 

--- a/src/Composer/PatchMoveToLocalCommand.php
+++ b/src/Composer/PatchMoveToLocalCommand.php
@@ -21,7 +21,7 @@ class PatchMoveToLocalCommand extends PatchBaseCommand {
     parent::configure();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $extra = $this->getComposer()->getPackage()->getExtra();
 
     if ($this->getPatchType() === self::PATCHTYPE_ROOT) {

--- a/src/Composer/PatchRemoveCommand.php
+++ b/src/Composer/PatchRemoveCommand.php
@@ -36,7 +36,7 @@ class PatchRemoveCommand extends PatchBaseCommand {
     }
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $extra = $extra = $this->getComposer()->getPackage()->getExtra();
     $package = $input->getArgument('package');
     $description = $input->getArgument('description');


### PR DESCRIPTION
To avoid this kind of errors:
```
Fatal error: Declaration of szeidler\ComposerPatchesCLI\Composer\PatchEnableCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /var/www/vendor/szeidler/composer-patches-cli/src/Composer/PatchEnableCommand.php on line 26

PHP Fatal error:  Declaration of szeidler\ComposerPatchesCLI\Composer\PatchEnableCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /var/www/vendor/szeidler/composer-patches-cli/src/Composer/PatchEnableCommand.php on line 26
```